### PR TITLE
1216365 kmd identity saml testapplication must sign saml auth requests

### DIFF
--- a/KMD.Identity.TestApplications.SAML.MVCCore/Controllers/AuthController.cs
+++ b/KMD.Identity.TestApplications.SAML.MVCCore/Controllers/AuthController.cs
@@ -27,6 +27,7 @@ namespace KMD.Identity.TestApplications.SAML.MVCCore.Controllers
         {
             var binding = new Saml2RedirectBinding();
             binding.SetRelayStateQuery(new Dictionary<string, string> { { relayStateReturnUrl, returnUrl ?? Url.Content("~/") } });
+            config.SignAuthnRequest = true;
             return binding.Bind(new Saml2AuthnRequest(config)).ToActionResultWithDomainHint(domainHint);
         }
         

--- a/KMD.Identity.TestApplications.SAML.MVCCore/Controllers/AuthController.cs
+++ b/KMD.Identity.TestApplications.SAML.MVCCore/Controllers/AuthController.cs
@@ -27,7 +27,6 @@ namespace KMD.Identity.TestApplications.SAML.MVCCore.Controllers
         {
             var binding = new Saml2RedirectBinding();
             binding.SetRelayStateQuery(new Dictionary<string, string> { { relayStateReturnUrl, returnUrl ?? Url.Content("~/") } });
-            config.SignAuthnRequest = true;
             return binding.Bind(new Saml2AuthnRequest(config)).ToActionResultWithDomainHint(domainHint);
         }
         

--- a/KMD.Identity.TestApplications.SAML.MVCCore/appsettings.json
+++ b/KMD.Identity.TestApplications.SAML.MVCCore/appsettings.json
@@ -14,7 +14,8 @@
     "SigningCertificateThumbprint": "",
     "SigningCertificatePassword": "!QAZ2wsx",
     "CertificateValidationMode": "None",
-    "RevocationMode": "NoCheck"
+    "RevocationMode": "NoCheck",
+    "SignAuthnRequest":  true
   },
   "AllowedHosts": "*",
   "ApplicationInsights": {


### PR DESCRIPTION
The SAML Testapplications needs to sign the auth request. This can be done by setting SignAutnRequest = true. This has been added to appsettings. 