### PR TITLE
1537654 update spa and net open id testapps in dev and prod to use another configuration endpoint

### DIFF
--- a/KMD.Identity.TestApplications.OpenID.API/appsettings.DevTest.json
+++ b/KMD.Identity.TestApplications.OpenID.API/appsettings.DevTest.json
@@ -7,7 +7,7 @@
     }
   },
   "Security": {
-    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/.well-known/openid-configuration",
+    "IdPMetadataUrl": "https://dev.identity.kmd.dk/adfs/services/trust/.well-known/openid-configuration",
     "ApplicationIdentifier": "urn:kmd-identity-test-application-api.dev"
   },
   "ApplicationInsights": {

--- a/KMD.Identity.TestApplications.OpenID.API/appsettings.Production.json
+++ b/KMD.Identity.TestApplications.OpenID.API/appsettings.Production.json
@@ -7,7 +7,7 @@
     }
   },
   "Security": {
-    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/.well-known/openid-configuration",
+    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/services/trust/.well-known/openid-configuration",
     "ApplicationIdentifier": "urn:kmd-identity-test-application-api.prod"
   },
   "ApplicationInsights": {

--- a/KMD.Identity.TestApplications.OpenID.API/appsettings.Sandbox.json
+++ b/KMD.Identity.TestApplications.OpenID.API/appsettings.Sandbox.json
@@ -7,7 +7,7 @@
     }
   },
   "Security": {
-    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/.well-known/openid-configuration",
+    "IdPMetadataUrl": "https://sandbox.identity.kmd.dk/adfs/services/trust/.well-known/openid-configurationn",
     "ApplicationIdentifier": "urn:kmd-identity-test-application-api.sandbox"
   },
   "ApplicationInsights": {

--- a/KMD.Identity.TestApplications.OpenID.API/appsettings.json
+++ b/KMD.Identity.TestApplications.OpenID.API/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AllowedHosts": "*",
   "Security": {
-    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/.well-known/openid-configuration",
+    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/services/trust/.well-known/openid-configuration",
     "ApplicationIdentifier": "urn:kmd-identity-test-application-api.local"
   },
   "ApplicationInsights": {

--- a/KMD.Identity.TestApplications.OpenID.MVCCore/appsettings.DevTest.json
+++ b/KMD.Identity.TestApplications.OpenID.MVCCore/appsettings.DevTest.json
@@ -7,7 +7,7 @@
     }
   },
   "Security": {
-    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/.well-known/openid-configuration",
+    "IdPMetadataUrl": "https://dev.identity.kmd.dk/adfs/services/trust/.well-known/openid-configuration",
     "ClientId": "",
     "ClientSecret": "",
     "ApiScope": "urn:kmd-identity-test-application-api.dev/user_impersonation openid allatclaims",

--- a/KMD.Identity.TestApplications.OpenID.MVCCore/appsettings.Production.json
+++ b/KMD.Identity.TestApplications.OpenID.MVCCore/appsettings.Production.json
@@ -7,7 +7,7 @@
     }
   },
   "Security": {
-    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/.well-known/openid-configuration",
+    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/services/trust/.well-known/openid-configuration",
     "ClientId": "",
     "ClientSecret": "",
     "ApiScope": "urn:kmd-identity-test-application-api.prod/user_impersonation openid allatclaims",

--- a/KMD.Identity.TestApplications.OpenID.MVCCore/appsettings.Sandbox.json
+++ b/KMD.Identity.TestApplications.OpenID.MVCCore/appsettings.Sandbox.json
@@ -7,7 +7,7 @@
     }
   },
   "Security": {
-    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/.well-known/openid-configuration",
+    "IdPMetadataUrl": "https://sandbox.identity.kmd.dk/adfs/services/trust/.well-known/openid-configuration",
     "ClientId": "",
     "ClientSecret": "",
     "ApiScope": "urn:kmd-identity-test-application-api.sandbox/user_impersonation openid allatclaims",

--- a/KMD.Identity.TestApplications.OpenID.MVCCore/appsettings.json
+++ b/KMD.Identity.TestApplications.OpenID.MVCCore/appsettings.json
@@ -8,7 +8,7 @@
   },
   "AllowedHosts": "*",
   "Security": {
-    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/.well-known/openid-configuration",
+    "IdPMetadataUrl": "https://identity.kmd.dk/adfs/services/trust/.well-known/openid-configuration",
     "ClientId": "d31a798f-d1b0-4673-9565-4da3573cd31d",
     "ClientSecret": "F4oKhIOAtsRLBIQyPip6BVOjzZbEUUz6PE7ZVDY_",
     "ApiScope": "urn:kmd-identity-test-application-api.local/user_impersonation openid allatclaims",


### PR DESCRIPTION
Updated IdPMetadataUrl for affected OpenID testapplications as requested in https://dev.azure.com/kmddk/KMD%20Identity/_boards/board/t/KMD%20Identity%20Team/Stories/?workitem=1537654

I have not identified any other places this change needs to be made but please do inform me in case something is missing.