### PR TITLE
Fixed errors calling the claims api from Angular test app

### DIFF
--- a/KMD.Identity.TestApplications.OpenID.API/Startup.cs
+++ b/KMD.Identity.TestApplications.OpenID.API/Startup.cs
@@ -74,16 +74,17 @@ namespace KMD.Identity.TestApplications.OpenID.API
 
             app.UseHttpsRedirection();
 
-            app.UseAuthentication();
-            app.UseRouting();
-            app.UseAuthorization();
-
             app.UseCors(options =>
             {
                 options.AllowAnyOrigin();
                 options.AllowAnyHeader();
                 options.AllowAnyMethod();
             });
+
+            app.UseAuthentication();
+            app.UseRouting();
+            app.UseAuthorization();
+
 
             app.UseEndpoints(endpoints =>
             {

--- a/KMD.Identity.TestApplications.OpenID.Angular/ClientApp/src/app/test-api-call/test-api-call.component.ts
+++ b/KMD.Identity.TestApplications.OpenID.Angular/ClientApp/src/app/test-api-call/test-api-call.component.ts
@@ -13,8 +13,8 @@ export class TestApiCallComponent implements OnInit {
     this.testApiCallService.testApiResponse$.subscribe(response => this.apiResponse = response);
   }
 
-  ngOnInit(): void { 
-    this.testApiCallService.callTestApi();
+  async ngOnInit() { 
+    await this.testApiCallService.callTestApi();
   }
 
 }

--- a/KMD.Identity.TestApplications.OpenID.Angular/ClientApp/src/app/test-api-call/test-api-call.service.ts
+++ b/KMD.Identity.TestApplications.OpenID.Angular/ClientApp/src/app/test-api-call/test-api-call.service.ts
@@ -17,11 +17,11 @@ export class TestApiCallService {
     private httpClient: HttpClient, 
     private appConfig: AppConfig) { }
 
-  public callTestApi() {
+  public async callTestApi() {
 
     const bearerHeaders = new HttpHeaders({
       'Content-Type': 'application/json',
-      'Authorization': 'Bearer ' + this.authenticationContext.accessToken()
+      'Authorization': 'Bearer ' + await this.authenticationContext.accessToken().toPromise()
     });
 
     this.httpClient.get(this.appConfig.security.apiUrl, { headers: bearerHeaders }).subscribe(response => this.testApiResponse.next(response));


### PR DESCRIPTION
Fixed two problems:
- CORS validation failed because it was placed at the wrong point of the setup sequence (not sure why this ever worked).
- The auth token was serialized as an observable rather than a string.