### PR TITLE
KMD Identity SAML test application returns exception when re-authenticating

### DIFF
--- a/KMD.Identity.TestApplications.SAML.MVCCore/Controllers/AuthController.cs
+++ b/KMD.Identity.TestApplications.SAML.MVCCore/Controllers/AuthController.cs
@@ -5,6 +5,7 @@ using KMD.Identity.TestApplications.SAML.MVCCore.Config;
 using KMD.Identity.TestApplications.SAML.MVCCore.Extensions;
 using KMD.Identity.TestApplications.SAML.MVCCore.Identity;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 using System;
@@ -53,8 +54,8 @@ namespace KMD.Identity.TestApplications.SAML.MVCCore.Controllers
                 saml2AuthnResponse,
                 config
             );
-
-            await saml2AuthnResponse.CreateSession(HttpContext, claimsTransform: (claimsPrincipal) => ClaimsTransform.Transform(claimsPrincipal));
+            if (!HttpContext.User.Identity.IsAuthenticated)
+                await saml2AuthnResponse.CreateSession(HttpContext, claimsTransform: (claimsPrincipal) => ClaimsTransform.Transform(claimsPrincipal));
 
             var relayStateQuery = binding.GetRelayStateQuery();
             var returnUrl = relayStateQuery.ContainsKey(relayStateReturnUrl) ? relayStateQuery[relayStateReturnUrl] : Url.Content("~/");

--- a/KMD.Identity.TestApplications.SAML.MVCCore/Controllers/AuthController.cs
+++ b/KMD.Identity.TestApplications.SAML.MVCCore/Controllers/AuthController.cs
@@ -31,6 +31,7 @@ namespace KMD.Identity.TestApplications.SAML.MVCCore.Controllers
             var binding = new Saml2RedirectBinding();
             binding.SetRelayStateQuery(new Dictionary<string, string> { { relayStateReturnUrl, returnUrl ?? Url.Content("~/") } });
             if (HttpContext.User.Identity.IsAuthenticated)
+            {
                 if (Url.IsLocalUrl(returnUrl))
                 {
                     return Redirect(returnUrl);
@@ -39,6 +40,7 @@ namespace KMD.Identity.TestApplications.SAML.MVCCore.Controllers
                 {
                     return Redirect(Url.Content("~/"));
                 }
+            }
             return binding.Bind(new Saml2AuthnRequest(config)).ToActionResultWithDomainHint(domainHint);
 
             //To use the Unilogin connection with a different flow than the default (one factor), 

--- a/KMD.Identity.TestApplications.SAML.MVCCore/Controllers/AuthController.cs
+++ b/KMD.Identity.TestApplications.SAML.MVCCore/Controllers/AuthController.cs
@@ -30,6 +30,15 @@ namespace KMD.Identity.TestApplications.SAML.MVCCore.Controllers
         {
             var binding = new Saml2RedirectBinding();
             binding.SetRelayStateQuery(new Dictionary<string, string> { { relayStateReturnUrl, returnUrl ?? Url.Content("~/") } });
+            if (HttpContext.User.Identity.IsAuthenticated)
+                if (Url.IsLocalUrl(returnUrl))
+                {
+                    return Redirect(returnUrl);
+                }
+                else
+                {
+                    return Redirect(Url.Content("~/"));
+                }
             return binding.Bind(new Saml2AuthnRequest(config)).ToActionResultWithDomainHint(domainHint);
 
             //To use the Unilogin connection with a different flow than the default (one factor), 
@@ -54,8 +63,8 @@ namespace KMD.Identity.TestApplications.SAML.MVCCore.Controllers
                 saml2AuthnResponse,
                 config
             );
-            if (!HttpContext.User.Identity.IsAuthenticated)
-                await saml2AuthnResponse.CreateSession(HttpContext, claimsTransform: (claimsPrincipal) => ClaimsTransform.Transform(claimsPrincipal));
+
+            await saml2AuthnResponse.CreateSession(HttpContext, claimsTransform: (claimsPrincipal) => ClaimsTransform.Transform(claimsPrincipal));
 
             var relayStateQuery = binding.GetRelayStateQuery();
             var returnUrl = relayStateQuery.ContainsKey(relayStateReturnUrl) ? relayStateQuery[relayStateReturnUrl] : Url.Content("~/");


### PR DESCRIPTION
![c6d2ef8c-243d-4a15-a845-69fab66a1e84](https://github.com/kmd-identity/testapplications/assets/5815127/9b76fbc1-346a-4590-9088-969db214f526)
