### PR TITLE
Spaexceptions

### DIFF
--- a/KMD.Identity.TestApplications.OpenID.Angular/Startup.cs
+++ b/KMD.Identity.TestApplications.OpenID.Angular/Startup.cs
@@ -1,10 +1,12 @@
 using KMD.Identity.TestApplications.OpenID.Angular.Config;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SpaServices.AngularCli;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using System;
 
 namespace KMD.Identity.TestApplications.OpenID.Angular
 {
@@ -54,6 +56,18 @@ namespace KMD.Identity.TestApplications.OpenID.Angular
             }
 
             app.UseRouting();
+
+            app.Use(async (context, next) =>
+            {
+                if (!context.Request.Method.Equals("GET", StringComparison.OrdinalIgnoreCase))
+                {
+                    context.Response.StatusCode = StatusCodes.Status405MethodNotAllowed;
+                    await context.Response.CompleteAsync();
+                    return;
+                }
+                await next();
+            });
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute(


### PR DESCRIPTION
Returning 405 if verb is not get to avoid getting exceptions when getting spammed with all sorts of weird requests.